### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ _Please refer back to this document as a checklist before issuing any pull reque
 ## Understanding the basics
 Not sure what a pull request is, or how to submit one?  Take a look at GitHub's excellent [help documentation][] first.
 
-[help documentation]: http://help.github.com/send-pull-requests
+[help documentation]: https://help.github.com/send-pull-requests
 
 ## Search GitHub Issues first; create an issue if necessary
 Is there already an issue that addresses your concern?  Do a bit of searching in our [GitHub issue tracker][] to see if you can find something similar. If not, please create a new issue before submitting a pull request unless the change is truly trivial, e.g. typo fixes, removing compiler warnings, etc.
@@ -66,7 +66,7 @@ then be sure to update it to 2014 appropriately
 ```
 
 ## Squash commits
-Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <http://git-scm.com/book/en/Git-Tools-Rewriting-History>.
+Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <https://git-scm.com/book/en/Git-Tools-Rewriting-History>.
 
 ## Use real name in git commits
 Please configure git to use your real first and last name for any commits you intend to submit as pull requests. For example, this is not acceptable:
@@ -131,7 +131,7 @@ Issue: #10, #11
 1. Mention associated GitHub issue(s) at the end of the commit comment, prefixed with "Issue: " as above
 1. In the body of the commit message, explain how things worked before this commit, what has changed, and how things work now
 
-[commit guidelines section of Pro Git]: http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
+[commit guidelines section of Pro Git]: https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
 
 ## Run all tests prior to submission
 See the [Running Tests][] section of the README for instructions. Make sure that all tests pass prior to submitting your pull request.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ This system test is released under version 2.0 of the [Apache License][].
 
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0
 [contributor guidelines]: CONTRIBUTING.md
-[Pull requests]: http://help.github.com/send-pull-requests
+[Pull requests]: https://help.github.com/send-pull-requests
 [Redis Manager]: https://github.com/gopivotal/session-
 [Session Managers]: https://github.com/gopivotal/session-managers

--- a/rakelib/tomcat_rake_task.rb
+++ b/rakelib/tomcat_rake_task.rb
@@ -38,7 +38,7 @@ class TomcatRakeTask < Rake::TaskLib
   private
 
   def url
-    "http://archive.apache.org/dist/tomcat/tomcat-#{@version.chars.first}/v#{@version}/bin" \
+    "https://archive.apache.org/dist/tomcat/tomcat-#{@version.chars.first}/v#{@version}/bin" \
     "/apache-tomcat-#{@version}.tar.gz"
   end
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://archive.apache.org/dist/tomcat/tomcat- (404) with 1 occurrences migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat- ([https](https://archive.apache.org/dist/tomcat/tomcat-) result 404).
* http://help.github.com/send-pull-requests (404) with 2 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 302).
* http://git-scm.com/book/en/Git-Tools-Rewriting-History with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Tools-Rewriting-History ([https](https://git-scm.com/book/en/Git-Tools-Rewriting-History) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences